### PR TITLE
Add support for the GNUstep Objective-C runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,31 @@
 language: rust
+rust:
+  - stable 
+  - beta
+  - nightly
 sudo: false
+install:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export FEATURE="gnustep"; export CC="clang"; export CXX="clang++"; else export FEATURE=""; fi
+  - if [[ "$FEATURE" == *"gnustep"* ]]; then git clone https://github.com/gnustep/libobjc2.git; fi
+  - if [[ "$FEATURE" == *"gnustep"* ]]; then mkdir libobjc2/build; pushd libobjc2/build; fi
+  - if [[ "$FEATURE" == *"gnustep"* ]]; then cmake -DCMAKE_INSTALL_PREFIX:PATH=$HOME/libobjc2_staging ../; fi
+  - if [[ "$FEATURE" == *"gnustep"* ]]; then make install; fi
+  - if [[ "$FEATURE" == *"gnustep"* ]]; then export CPATH=$HOME/libobjc2_staging/include:$CPATH; export LIBRARY_PATH=$HOME/libobjc2_staging/lib:$LIBRARY_PATH; LD_LIBRARY_PATH=$HOME/libobjc2_staging/lib:$LD_LIBRARY_PATH; fi
+  - if [[ "$FEATURE" == *"gnustep"* ]]; then popd; fi
+  - if [ -n "$FEATURE" ]; then export FEATURES="--features $FEATURE"; else export FEATURES=""; fi;
+script:
+  - cargo build $FEATURES
+  - cargo test $FEATURES
+  - cargo doc $FEATURES
+env:
+notifications:
+  email:
+    on_success: never
 os:
+  - linux
   - osx
+addons:
+  apt:
+    packages:
+      - clang-3.7
+      - cmake

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,12 @@ repository = "http://github.com/SSheldon/rust-objc"
 documentation = "http://ssheldon.github.io/rust-objc/objc/"
 license = "MIT"
 
-exclude = [".gitignore", ".travis.yml", "ios-tests/**", "xtests/**"]
+exclude = [".gitignore", "ios-tests/**", "xtests/**", ".travis.yml"]
 
 [features]
 exception = ["objc_exception"]
 verify_message = []
+gnustep = [ "test_ns_object/gnustep" ]
 
 [dependencies]
 malloc_buf = "0.0"
@@ -22,3 +23,7 @@ malloc_buf = "0.0"
 [dependencies.objc_exception]
 version = "0.1"
 optional = true
+
+[dev-dependencies.test_ns_object]
+version = "0.0"
+path = "test_utils"

--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ will unwind into Rust resulting in unsafe, undefined behavior.
 However, this crate has an `"exception"` feature which, when enabled, wraps
 each `msg_send!` in a `@try`/`@catch` and panics if an exception is caught,
 preventing Objective-C from unwinding into Rust.
+
+## Support for other Operating Systems
+
+The bindings can be used on Linux or *BSD utilizing the
+[GNUstep Objective-C runtime](https://www.github.com/gnustep/libobjc2).
+To enable it, you need to pass the required feature to cargo:
+`cargo build --feature gnustep`.

--- a/src/declare.rs
+++ b/src/declare.rs
@@ -9,7 +9,7 @@ methods can then be added before the class is ultimately registered.
 The following example demonstrates declaring a class named `MyNumber` that has
 one ivar, a `u32` named `_number` and a `number` method that returns it:
 
-```
+```no_run
 # #[macro_use] extern crate objc;
 # use objc::declare::ClassDecl;
 # use objc::runtime::{Class, Object, Sel};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ Objective-C Runtime bindings and wrapper for Rust.
 
 Objective-C objects can be messaged using the [`msg_send!`](macro.msg_send!.html) macro:
 
-```
+```no_run
 # #[macro_use] extern crate objc;
 # use objc::runtime::{BOOL, Class, Object};
 # fn main() {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -38,6 +38,27 @@ pub struct Sel {
     ptr: *const c_void,
 }
 
+
+/// A structure describing a safely cacheable method implementation
+/// in the GNUstep Objective-C runtime.
+#[cfg(feature="gnustep")]
+#[repr(C)]
+pub struct Slot  {
+  /// The class to which the slot is attached
+  pub owner: *const Class,
+  /// The class for which this slot was cached.
+  pub cached_for: *mut Class,
+  /// The type signature of the method
+  pub types: *const c_char,
+  /// The version of the method. Will change if overriden, invalidating
+  /// the cache
+  pub version: c_int,
+  /// The implementation of the method
+  pub method: Imp,
+  /// The associated selector
+  pub selector: Sel
+}
+
 /// A marker type to be embedded into other types just so that they cannot be
 /// constructed externally.
 enum PrivateMarker { }
@@ -79,7 +100,7 @@ pub struct Super {
 pub type Imp = extern fn(*mut Object, Sel, ...) -> *mut Object;
 
 #[link(name = "objc", kind = "dylib")]
-extern {
+extern "C" {
     pub fn sel_registerName(name: *const c_char) -> Sel;
     pub fn sel_getName(sel: Sel) -> *const c_char;
 
@@ -123,6 +144,11 @@ extern {
     pub fn method_getNumberOfArguments(method: *const Method) -> c_uint;
     pub fn method_setImplementation(method: *mut Method, imp: Imp) -> Imp;
     pub fn method_exchangeImplementations(m1: *mut Method, m2: *mut Method);
+
+    #[cfg(feature="gnustep")]
+    pub fn objc_msg_lookup_sender(receiver: *mut *mut Object, selector: Sel, sender: *mut Object, ...) -> *mut Slot;
+    #[cfg(feature="gnustep")]
+    pub fn objc_slot_lookup_super(sup: *const Super, selector: Sel) -> *mut Slot;
 }
 
 impl Sel {
@@ -444,7 +470,7 @@ mod tests {
         assert!(method.name().name() == "description");
         assert!(method.arguments_count() == 2);
         assert!(method.return_type() == <*mut Object>::encode());
-        assert!(method.argument_type(1).unwrap() == Sel::encode());
+        assert_eq!(method.argument_type(1).unwrap(), Sel::encode());
 
         let methods = cls.instance_methods();
         assert!(methods.len() > 0);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -5,6 +5,15 @@ use id::StrongPtr;
 use runtime::{Class, Object, Sel};
 use {Encode, Encoding};
 
+
+
+
+#[cfg(feature="gnustep")]
+#[link(name = "NSObject", kind = "static")]
+extern {
+}
+
+
 pub fn sample_object() -> StrongPtr {
     let cls = Class::get("NSObject").unwrap();
     unsafe {

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "test_ns_object"
+version = "0.0.1"
+authors = ["Niels Grewe"]
+
+description = "Mock implementation of NSObject for tests"
+repository = "http://github.com/SSheldon/rust-objc"
+license = "MIT"
+
+build = "build.rs"
+
+[features]
+gnustep = [ "gcc" ]
+
+[lib]
+name = "test_ns_object"
+path = "lib.rs"
+
+[build-dependencies.gcc]
+gcc = "0.3"
+optional = true

--- a/test_utils/NSObject.m
+++ b/test_utils/NSObject.m
@@ -1,0 +1,45 @@
+#include <objc/runtime.h>
+#include <stdint.h>
+/**
+ * This is a mock implementation of NSObject, which will be linked against
+ * the tests in order to provide a superclass for them.
+ */
+__attribute__((objc_root_class))
+@interface NSObject
+{
+  Class isa;
+}
+@end
+
+@implementation NSObject 
+
++ (id)alloc
+{
+  return class_createInstance(self, 0);	
+}
+
+- (id)init
+{
+  return self;
+}
+
+- (id)self
+{
+  return self;
+}
+
+- (uintptr_t)hash
+{
+  return (uintptr_t)(void*)self;
+}
+
+- (void)dealloc
+{
+  object_dispose(self);
+}
+
+- (NSObject*)description
+{
+  return nil;
+}
+@end

--- a/test_utils/build.rs
+++ b/test_utils/build.rs
@@ -1,0 +1,23 @@
+#[cfg(feature="gnustep")]
+extern crate gcc;
+#[cfg(feature="gnustep")]
+use std::path::PathBuf;
+
+
+#[cfg(not(feature="gnustep"))]
+fn compile() {
+}
+
+#[cfg(feature="gnustep")]
+fn compile() {
+    gcc::Config::new().flag("-lobjc")
+                      .flag("-fobjc-runtime=gnustep-1.8")
+                      .flag("-fno-objc-legacy-dispatch")
+                      .file("NSObject.m")
+                      .compile("libNSObject.a");
+    let path = ::std::env::var_os("OUT_DIR").map(PathBuf::from).unwrap();
+    println!("cargo:rustc-link-search=native={}", path.display()); 
+}
+fn main() {
+    compile();
+}

--- a/test_utils/lib.rs
+++ b/test_utils/lib.rs
@@ -1,0 +1,3 @@
+#![crate_name = "test_ns_object"]
+#![crate_type = "lib"]
+


### PR DESCRIPTION
Hi!

I've fiddled with a few things and gotten the bindings to work with the GNUstep Objective-C runtime, so that they can also be used for interop between Rust and Objective-C code on non-Apple platforms. It's controlled by a new feature called `gnustep_runtime`, 

This mainly involved adding support for the slightly different message sending mechanism. Also getting the tests back into working order proved a bit difficult because if you're not on Mac OS or iOS you usually don't have NSObject available unless you link a Foundation implementation. I've made it so that the bindings will build without one, but the tests will need to link the GNUstep base library (Foundation equivalent) in order to run. 

There's also an outstanding bug in the runtime that I found thanks to the unit tests in rust-objc ;-)

Also, I've tested on Mac OS for regressions and things should continue to work there as expected.