### PR TITLE
to_owned should be used in favor of to_string

### DIFF
--- a/src/declare.rs
+++ b/src/declare.rs
@@ -135,7 +135,7 @@ method_decl_impl!(A, B, C, D, E, F, G, H, I, J, K);
 method_decl_impl!(A, B, C, D, E, F, G, H, I, J, K, L);
 
 fn method_type_encoding<F>() -> CString where F: MethodImplementation {
-    let mut types = F::Ret::encode().as_str().to_string();
+    let mut types = F::Ret::encode().as_str().to_owned();
     types.extend(F::argument_encodings().iter().map(|e| e.as_str()));
     CString::new(types).unwrap()
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -77,7 +77,7 @@ pub fn from_static_str(code: &'static str) -> Encoding {
 
 pub fn from_str(code: &str) -> Encoding {
     if code.len() > CODE_INLINE_CAP {
-        Encoding { code: Code::Owned(code.to_string()) }
+        Encoding { code: Code::Owned(code.to_owned()) }
     } else {
         let mut bytes = [0; CODE_INLINE_CAP];
         for (dst, byte) in bytes.iter_mut().zip(code.bytes()) {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -24,7 +24,7 @@ pub struct CustomStruct {
 
 unsafe impl Encode for CustomStruct {
     fn encode() -> Encoding {
-        let mut code = "{CustomStruct=".to_string();
+        let mut code = "{CustomStruct=".to_owned();
         for _ in 0..4 {
             code.push_str(u64::encode().as_str());
         }


### PR DESCRIPTION
Hi, this PR stumbles upon a small nit I covered while seeking some code in cocoa-rs and servo.

It fixes the to_string calls for to_owned. It is much lighter in resources.

To_string as uses the whole formatting machinery just to clone a string. 

Thanks for looking into it !