### PR TITLE
Add protocols

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,8 +1,9 @@
 use std::ops::{Deref, DerefMut};
+use std::os::raw::c_char;
 use std::sync::{Once, ONCE_INIT};
 
-use declare::ClassDecl;
-use runtime::{Class, Object, Sel, self};
+use declare::{ClassDecl, ProtocolDecl};
+use runtime::{Class, Object, Protocol, Sel, self};
 use {Encode, Encoding};
 
 pub struct CustomObject {
@@ -69,7 +70,9 @@ pub fn custom_class() -> &'static Class {
         extern fn custom_obj_class_initialize(_this: &Class, _cmd: Sel) { }
 
         let mut decl = ClassDecl::root("CustomObject", custom_obj_class_initialize).unwrap();
+        let proto = custom_protocol();
 
+        decl.add_protocol(proto);
         decl.add_ivar::<u32>("_foo");
 
         extern fn custom_obj_set_foo(this: &mut Object, _cmd: Sel, foo: u32) {
@@ -88,6 +91,14 @@ pub fn custom_class() -> &'static Class {
             7
         }
 
+        extern fn custom_obj_set_bar(this: &mut Object, _cmd: Sel, bar: u32) {
+            unsafe { this.set_ivar::<u32>("_foo", bar) ;}
+        }
+
+        extern fn custom_obj_add_number_to_number(_this: &Class, _cmd: Sel, fst: i32, snd: i32) -> i32 {
+            fst + snd
+        }
+
         unsafe {
             let set_foo: extern fn(&mut Object, Sel, u32) = custom_obj_set_foo;
             decl.add_method(sel!(setFoo:), set_foo);
@@ -97,12 +108,49 @@ pub fn custom_class() -> &'static Class {
             decl.add_method(sel!(customStruct), get_struct);
             let class_method: extern fn(&Class, Sel) -> u32 = custom_obj_class_method;
             decl.add_class_method(sel!(classFoo), class_method);
+
+            let protocol_instance_method: extern fn(&mut Object, Sel, u32) = custom_obj_set_bar;
+            decl.add_method(sel!(setBar:), protocol_instance_method);
+            let protocol_class_method: extern fn(&Class, Sel, i32, i32) -> i32 = custom_obj_add_number_to_number;
+            decl.add_class_method(sel!(addNumber:toNumber:), protocol_class_method);
         }
 
         decl.register();
     });
 
     Class::get("CustomObject").unwrap()
+}
+
+pub fn custom_protocol() -> &'static Protocol {
+    static REGISTER_CUSTOM_PROTOCOL: Once = ONCE_INIT;
+
+    REGISTER_CUSTOM_PROTOCOL.call_once(|| {
+        let mut decl = ProtocolDecl::new("CustomProtocol").unwrap();
+
+        decl.add_method_description::<(i32,), ()>(sel!(setBar:), true);
+        decl.add_method_description::<(), *const c_char>(sel!(getName), false);
+        decl.add_class_method_description::<(i32, i32), i32>(sel!(addNumber:toNumber:), true);
+
+        decl.register();
+    });
+
+    Protocol::get("CustomProtocol").unwrap()
+}
+
+pub fn custom_subprotocol() -> &'static Protocol {
+    static REGISTER_CUSTOM_SUBPROTOCOL: Once = ONCE_INIT;
+
+    REGISTER_CUSTOM_SUBPROTOCOL.call_once(|| {
+        let super_proto = custom_protocol();
+        let mut decl = ProtocolDecl::new("CustomSubProtocol").unwrap();
+
+        decl.add_protocol(super_proto);
+        decl.add_method_description::<(u32,), u32>(sel!(calculateFoo:), true);
+
+        decl.register();
+    });
+
+    Protocol::get("CustomSubProtocol").unwrap()
 }
 
 pub fn custom_object() -> CustomObject {


### PR DESCRIPTION
Adds protocol support to rust-objc. This request adds the `Protocol` and `ProtocolDecl` structs, and lets you build `Protocols`, as well as query them. It also adds a test for protocol conformance to the `Class` struct.