### PR TITLE
msg_send! with dynamic resolution of superclasses

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -56,6 +56,24 @@ let _: () = msg_send![obj, setArg1:1 arg2:2];
 */
 #[macro_export]
 macro_rules! msg_send {
+    (super($obj:expr), $name:ident) => ({
+        let sel = sel!($name);
+        let receiver_class = $obj.class();
+        let superclass : &$crate::runtime::Class = &*$crate::runtime::class_getSuperclass(receiver_class);
+        match $crate::__send_super_message(&*$obj, superclass, sel, ()) {
+            Err(s) => panic!("{}", s),
+            Ok(r) => r,
+        }
+    });
+    (super($obj:expr), $($name:ident : $arg:expr)+) => ({
+        let sel = sel!($($name:)+);
+        let receiver_class = $obj.class();
+        let superclass : &$crate::runtime::Class = &*$crate::runtime::class_getSuperclass(receiver_class);
+        match $crate::__send_super_message(&*$obj, superclass, sel, ($($arg,)*)) {
+            Err(s) => panic!("{}", s),
+            Ok(r) => r,
+        }
+    });
     (super($obj:expr, $superclass:expr), $name:ident) => ({
         let sel = sel!($name);
         match $crate::__send_super_message(&*$obj, $superclass, sel, ()) {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -308,6 +308,15 @@ mod tests {
             // The subclass is overriden to return foo + 2
             let foo: u32 = msg_send![obj, foo];
             assert!(foo == 6);
+
+            // This is the second variant of sending messages to super, used when the superclass is
+            // unknown at compile time.
+            let foo: u32 = msg_send![super(obj), foo];
+            assert!(foo == 4);
+
+            // The subclass is overriden to return foo + 2
+            let foo: u32 = msg_send![obj, foo];
+            assert!(foo == 6);
         }
     }
 


### PR DESCRIPTION
Hi SSheldon,

for sending messages to super, the msg_send! macro currently expects you to pass the superclass explicitly:

```rust
msg_send![super(obj, superclass), foo]
```

I recently ran into a situation where I wanted to declare new subclasses in Rust were supposed to be generic over a number of superclasses. To that end, it increases ergonomics quite a bit to have the macro do the class lookup for you:

```rust
msg_send![super(obj), foo]
```

That's of course less efficient most of the time, so it doesn't invalidate the other way of sending messages to super, but I believe it's a nice gain in ergonomics when you can't rely on a fixed superclass.

Cheers,

Niels