### PR TITLE
Cache selectors so we don't call `sel_registerName` over and over.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Steven Sheldon"]
 
 description = "Objective-C Runtime bindings and wrapper for Rust."

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -147,6 +147,22 @@ impl Sel {
         };
         str::from_utf8(name.to_bytes()).unwrap()
     }
+
+    /// Wraps a raw pointer to a selector into a `Sel` object.
+    ///
+    /// This is almost never what you want; use `Sel::register()` instead.
+    #[inline]
+    pub unsafe fn from_ptr(ptr: *const c_void) -> Sel {
+        Sel {
+            ptr,
+        }
+    }
+
+    /// Returns a pointer to the raw selector.
+    #[inline]
+    pub fn as_ptr(&self) -> *const c_void {
+        self.ptr
+    }
 }
 
 impl PartialEq for Sel {


### PR DESCRIPTION
Improves #49.

This is what the assembly looks like. The fast path is only 4 instructions.

		lea    r15, [rip + 0xbf936]      ; cocoa::foundation::NSString::alloc::register_sel::SEL::h005daf5ee04d2745
		mov    rbx, qword ptr [r15]
		test   rbx, rbx
		jne    ok
		lea    rdi, [rip + 0x95b2c]      ; byte_str.o.llvm.2369336028792347561
		call   0x10008fa02               ; symbol stub for: sel_registerName
		mov    rbx, rax
		mov    qword ptr [r15], rbx
	ok:

cc @jrmuizel, @kvark, @mystor