### PR TITLE
Add a generic return type to autoreleasepool()

### DIFF
--- a/src/rc/autorelease.rs
+++ b/src/rc/autorelease.rs
@@ -23,7 +23,7 @@ Execute `f` in the context of a new autorelease pool. The pool is drained
 after the execution of `f` completes. This corresponds to @autoreleasepool blocks
 in Objective-c and Swift.
 */
-pub fn autoreleasepool<F: FnOnce()>(f: F) {
+pub fn autoreleasepool<T, F: FnOnce() -> T>(f: F) -> T {
     let _context = unsafe { AutoReleaseHelper::new() };
-    f();
+    f()
 }


### PR DESCRIPTION
This is a general usability improvement that lets users
easily get values out of the closure.

While this is technically a breaking change I think it would be best to let it slide. I don't think there are any users of autoreleasepool() yet and even if there are this change is unlikely to break them.