### PR TITLE
Use 'AtomicUsize::new' instead of 'ATOMIC_USIZE_INIT' (stable as of 1.24.0 on 2018-02-15)

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,6 +18,7 @@ macro_rules! class {
         #[inline(always)]
         fn get_class(name: &str) -> Option<&'static $crate::runtime::Class> {
             unsafe {
+                #[cfg_attr(feature = "cargo-clippy", allow(replace_consts))]
                 static CLASS: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::ATOMIC_USIZE_INIT;
                 // `Relaxed` should be fine since `objc_getClass` is thread-safe.
                 let ptr = CLASS.load(::std::sync::atomic::Ordering::Relaxed) as *const $crate::runtime::Class;
@@ -46,6 +47,7 @@ macro_rules! sel_impl {
         #[inline(always)]
         fn register_sel(name: &str) -> $crate::runtime::Sel {
             unsafe {
+                #[cfg_attr(feature = "cargo-clippy", allow(replace_consts))]
                 static SEL: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::ATOMIC_USIZE_INIT;
                 let ptr = SEL.load(::std::sync::atomic::Ordering::Relaxed) as *const ::std::os::raw::c_void;
                 // It should be fine to use `Relaxed` ordering here because `sel_registerName` is


### PR DESCRIPTION
Primary reason is I get dozens of 

```rust
warning: using `ATOMIC_USIZE_INIT`
  --> filename:66:13
   |
66 |             msg_send![ ... ];
   |             ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `AtomicUsize::new(0)`
   |
```

with clippy in pedantic mode.