### PR TITLE
Make objc macros compatible with `use macro!`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -79,8 +79,8 @@ let sel = sel!(setObject:forKey:);
 */
 #[macro_export]
 macro_rules! sel {
-    ($name:ident) => ({sel_impl!(concat!(stringify!($name), '\0'))});
-    ($($name:ident :)+) => ({sel_impl!(concat!($(stringify!($name), ':'),+, '\0'))});
+    ($name:ident) => ({$crate::sel_impl!(concat!(stringify!($name), '\0'))});
+    ($($name:ident :)+) => ({$crate::sel_impl!(concat!($(stringify!($name), ':'),+, '\0'))});
 }
 
 /**
@@ -108,28 +108,28 @@ let _: () = msg_send![obj, setArg1:1 arg2:2];
 #[macro_export]
 macro_rules! msg_send {
     (super($obj:expr, $superclass:expr), $name:ident) => ({
-        let sel = sel!($name);
+        let sel = $crate::sel!($name);
         match $crate::__send_super_message(&*$obj, $superclass, sel, ()) {
             Err(s) => panic!("{}", s),
             Ok(r) => r,
         }
     });
     (super($obj:expr, $superclass:expr), $($name:ident : $arg:expr)+) => ({
-        let sel = sel!($($name:)+);
+        let sel = $crate::sel!($($name:)+);
         match $crate::__send_super_message(&*$obj, $superclass, sel, ($($arg,)*)) {
             Err(s) => panic!("{}", s),
             Ok(r) => r,
         }
     });
     ($obj:expr, $name:ident) => ({
-        let sel = sel!($name);
+        let sel = $crate::sel!($name);
         match $crate::__send_message(&*$obj, sel, ()) {
             Err(s) => panic!("{}", s),
             Ok(r) => r,
         }
     });
     ($obj:expr, $($name:ident : $arg:expr)+) => ({
-        let sel = sel!($($name:)+);
+        let sel = $crate::sel!($($name:)+);
         match $crate::__send_message(&*$obj, sel, ($($arg,)*)) {
             Err(s) => panic!("{}", s),
             Ok(r) => r,

--- a/tests/use_macros.rs
+++ b/tests/use_macros.rs
@@ -1,0 +1,23 @@
+#![cfg(any(target_os = "macos", target_os = "ios"))]
+
+extern crate objc;
+
+use objc::{class, msg_send, sel};
+use objc::runtime::Object;
+
+#[test]
+fn use_class_and_msg_send() {
+    unsafe {
+        let cls = class!(NSObject);
+        let obj: *mut Object = msg_send![cls, new];
+        let _hash: usize = msg_send![obj, hash];
+        let _: () = msg_send![obj, release];
+    }
+}
+
+#[test]
+fn use_sel() {
+    let _sel = sel!(description);
+    let _sel = sel!(setObject:forKey:);
+}
+


### PR DESCRIPTION
`use`ing macros is rust's new feature that came to replace `#[macro_use]`.
In this PR I've added support for this feature.