### PR TITLE
Change docs link to docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Objective-C Runtime bindings and wrapper for Rust."
 keywords = ["objective-c", "osx", "ios", "cocoa", "uikit"]
 readme = "README.md"
 repository = "http://github.com/SSheldon/rust-objc"
-documentation = "http://ssheldon.github.io/rust-objc/objc/"
+documentation = "https://docs.rs/objc/"
 license = "MIT"
 
 exclude = [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Objective-C Runtime bindings and wrapper for Rust.
 
-* Documentation: http://docs.rs/objc/
+* Documentation: https://docs.rs/objc/
 * Crate: https://crates.io/crates/objc
 
 ## Messaging objects

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Objective-C Runtime bindings and wrapper for Rust.
 
-* Documentation: http://ssheldon.github.io/rust-objc/objc/
+* Documentation: http://docs.rs/objc/
 * Crate: https://crates.io/crates/objc
 
 ## Messaging objects


### PR DESCRIPTION
Docs on ssheldon.github.io are outdated in relation to docs.rs.