### PR TITLE
Test 32bit on Rust 1.41

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       env: FEATURES="exception verify_message" IOS_ARCHS=""
     - os: osx
       osx_image: xcode7.3
-      rust: stable
+      rust: 1.41.0
       env: FEATURES="exception" IOS_ARCHS="i386 x86_64 armv7 armv7s aarch64"
 sudo: false
 install: ./travis_install.sh


### PR DESCRIPTION
Support was removed starting in 1.42: https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html