### PR TITLE
Add Retained smart pointer

### DIFF
--- a/src/rc/mod.rs
+++ b/src/rc/mod.rs
@@ -40,12 +40,14 @@ assert!(weak.load().is_null());
 ```
 */
 
+mod owned;
 mod retained;
 mod strong;
 mod weak;
 mod autorelease;
 
 pub use self::retained::Retained;
+pub use self::owned::Owned;
 pub use self::strong::StrongPtr;
 pub use self::weak::WeakPtr;
 pub use self::autorelease::autoreleasepool;

--- a/src/rc/mod.rs
+++ b/src/rc/mod.rs
@@ -40,10 +40,12 @@ assert!(weak.load().is_null());
 ```
 */
 
+mod retained;
 mod strong;
 mod weak;
 mod autorelease;
 
+pub use self::retained::Retained;
 pub use self::strong::StrongPtr;
 pub use self::weak::WeakPtr;
 pub use self::autorelease::autoreleasepool;
@@ -54,25 +56,6 @@ mod tests {
     use crate::runtime::Object;
     use super::StrongPtr;
     use super::autoreleasepool;
-
-    #[test]
-    fn test_strong_clone() {
-        fn retain_count(obj: *mut Object) -> usize {
-            unsafe { msg_send![obj, retainCount] }
-        }
-
-        let obj = unsafe {
-            StrongPtr::new(msg_send![class!(NSObject), new])
-        };
-        assert!(retain_count(*obj) == 1);
-
-        let cloned = obj.clone();
-        assert!(retain_count(*cloned) == 2);
-        assert!(retain_count(*obj) == 2);
-
-        drop(obj);
-        assert!(retain_count(*cloned) == 1);
-    }
 
     #[test]
     fn test_weak() {

--- a/src/rc/owned.rs
+++ b/src/rc/owned.rs
@@ -1,0 +1,160 @@
+use core::marker::PhantomData;
+use core::ptr::{NonNull, drop_in_place};
+use core::mem;
+use core::ops::{DerefMut, Deref};
+use core::fmt;
+use core::hash;
+use core::borrow;
+
+use super::Retained;
+use crate::runtime::{self, Object};
+
+/// A smart pointer that strongly references and owns an Objective-C object.
+///
+/// The fact that we own the pointer means that we're safe to mutate it, hence
+/// why this implements [`DerefMut`].
+///
+/// This is guaranteed to have the same size as the underlying pointer.
+///
+/// TODO: Explain similarities to [`Box`].
+///
+/// TODO: Explain this vs. [`Retained`]
+#[repr(transparent)]
+pub struct Owned<T> {
+    /// The pointer is always retained.
+    pub(super) ptr: NonNull<T>, // Covariant
+    phantom: PhantomData<T>, // Necessary for dropcheck
+}
+
+// SAFETY: TODO
+unsafe impl<T: Send> Send for Owned<T> {}
+
+// SAFETY: TODO
+unsafe impl<T: Sync> Sync for Owned<T> {}
+
+impl<T> Owned<T> {
+    #[inline]
+    pub unsafe fn new(ptr: NonNull<T>) -> Self {
+        Self {
+            ptr,
+            phantom: PhantomData,
+        }
+    }
+
+    // TODO: Unsure how the API should look...
+    #[inline]
+    pub unsafe fn retain(ptr: NonNull<T>) -> Self {
+        Self::from_retained(Retained::retain(ptr))
+    }
+
+    /// TODO
+    ///
+    /// # Safety
+    ///
+    /// The given [`Retained`] must be the only reference to the object
+    /// anywhere in the program - even in other Objective-C code.
+    #[inline]
+    pub unsafe fn from_retained(obj: Retained<T>) -> Self {
+        let ptr = mem::ManuallyDrop::new(obj).ptr;
+        Self {
+            ptr,
+            phantom: PhantomData,
+        }
+    }
+}
+
+// TODO: #[may_dangle]
+// https://doc.rust-lang.org/nightly/nomicon/dropck.html
+impl<T> Drop for Owned<T> {
+    /// Releases the retained object
+    ///
+    /// This is guaranteed to be the last destructor that runs, in contrast to
+    /// [`Retained`], which means that we can run the [`Drop`] implementation
+    /// on the contained object as well.
+    #[inline]
+    fn drop(&mut self) {
+        let ptr = self.ptr;
+        unsafe {
+            drop_in_place(ptr.as_ptr());
+            // Construct a new `Retained`, which will be dropped immediately
+            Retained::new(ptr);
+        };
+    }
+}
+
+// Note: `Clone` is not implemented for this!
+
+impl<T> Deref for Owned<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: TODO
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T> DerefMut for Owned<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: TODO
+        unsafe { self.ptr.as_mut() }
+    }
+}
+
+// TODO: impl PartialEq, PartialOrd, Ord and Eq
+
+impl<T: fmt::Display> fmt::Display for Owned<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Owned<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T> fmt::Pointer for Owned<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Pointer::fmt(&self.ptr.as_ptr(), f)
+    }
+}
+
+impl<T: hash::Hash> hash::Hash for Owned<T> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        (&**self).hash(state)
+    }
+}
+
+// TODO: impl Fn traits? See `boxed_closure_impls`
+
+// TODO: CoerceUnsized
+
+impl<T> borrow::Borrow<T> for Owned<T> {
+    fn borrow(&self) -> &T {
+        &**self
+    }
+}
+
+impl<T> borrow::BorrowMut<T> for Owned<T> {
+    fn borrow_mut(&mut self) -> &mut T {
+        &mut **self
+    }
+}
+
+impl<T> AsRef<T> for Owned<T> {
+    fn as_ref(&self) -> &T {
+        &**self
+    }
+}
+
+impl<T> AsMut<T> for Owned<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut **self
+    }
+}
+
+// TODO: Comment on impl Unpin for Box
+impl<T> Unpin for Owned<T> {}

--- a/src/rc/owned.rs
+++ b/src/rc/owned.rs
@@ -16,6 +16,18 @@ use crate::runtime::{self, Object};
 ///
 /// This is guaranteed to have the same size as the underlying pointer.
 ///
+/// # Cloning and [`Retained`]
+///
+/// This does not implement [`Clone`], but [`Retained`] has a [`From`]
+/// implementation to convert from this, so you can easily reliquish ownership
+/// and work with a normal [`Retained`] pointer.
+///
+/// ```no_run
+/// let obj: Owned<T> = ...;
+/// let retained: Retained<T> = obj.into();
+/// let cloned: Retained<T> = retained.clone();
+/// ```
+///
 /// TODO: Explain similarities to [`Box`].
 ///
 /// TODO: Explain this vs. [`Retained`]
@@ -43,7 +55,8 @@ impl<T> Owned<T> {
     /// else, usually Objective-C methods like `init`, `alloc`, `new`, or
     /// `copy`).
     ///
-    /// Additionally, there must be no other pointers to the same object.
+    /// Additionally, there must be no other pointers or references to the same
+    /// object, and the given reference must not be used afterwards.
     ///
     /// # Example
     ///
@@ -55,6 +68,8 @@ impl<T> Owned<T> {
     /// ```
     ///
     /// TODO: Something about there not being other references.
+    // Note: The fact that we take a `&mut` here is more of a lint; the lifetime
+    // information is lost, so whatever produced the reference can still be
     #[inline]
     pub unsafe fn new(obj: &mut T) -> Self {
         Self {

--- a/src/rc/retained.rs
+++ b/src/rc/retained.rs
@@ -1,0 +1,245 @@
+use core::borrow;
+use core::fmt;
+use core::hash;
+use core::marker::{PhantomData, Unpin};
+use core::mem;
+use core::ops::Deref;
+use core::ptr::NonNull;
+
+use crate::runtime::{self, Object};
+
+/// A smart pointer that strongly references an object, ensuring it won't be
+/// deallocated.
+///
+/// This is guaranteed to have the same size as the underlying pointer.
+///
+/// ## Caveats
+///
+/// If the inner type implements [`Drop`], that implementation will not be
+/// called, since there is no way to ensure that the Objective-C runtime will
+/// do so. If you need to run some code when the object is destroyed,
+/// implement the `dealloc` selector instead.
+///
+/// TODO: Explain similarities with `Arc` and `RefCell`.
+#[repr(transparent)]
+pub struct Retained<T> {
+    /// A pointer to the contained object.
+    ///
+    /// It is important that this is `NonNull`, since we want to dereference
+    /// it later.
+    ///
+    /// Usually the contained object would be an [extern type][extern-type-rfc]
+    /// (when that gets stabilized), or a type such as:
+    /// ```
+    /// pub struct MyType {
+    ///     _data: [u8; 0], // TODO: `UnsafeCell`?
+    /// }
+    /// ```
+    ///
+    /// DSTs that carry metadata cannot be used here, so unsure if we should
+    /// have a `?Sized` bound?
+    ///
+    /// TODO:
+    /// https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait
+    /// https://doc.rust-lang.org/nomicon/exotic-sizes.html
+    /// https://doc.rust-lang.org/core/ptr/trait.Pointee.html
+    /// https://doc.rust-lang.org/core/ptr/traitalias.Thin.html
+    ///
+    /// [extern-type-rfc]: https://github.com/rust-lang/rfcs/blob/master/text/1861-extern-types.md
+    ptr: NonNull<T>, // Covariant
+    phantom: PhantomData<T>,
+}
+
+impl<T> Retained<T> {
+    /// Constructs a `Retained<T>` to an object that already has a +1 retain
+    /// count. This will not retain the object.
+    ///
+    /// When dropped, the object will be released.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the given object pointer is valid, and has +1
+    /// retain count.
+    ///
+    /// TODO: Something about there not being any mutable references.
+    #[inline]
+    pub const unsafe fn new(ptr: NonNull<T>) -> Self {
+        Retained {
+            ptr,
+            phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub const fn as_ptr(&self) -> *mut T {
+        self.ptr.as_ptr()
+    }
+
+    /// Retains the given object pointer.
+    ///
+    /// When dropped, the object will be released.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the given object pointer is valid.
+    #[doc(alias = "objc_retain")]
+    #[inline]
+    pub unsafe fn retain(ptr: NonNull<T>) -> Self {
+        // SAFETY: The caller upholds that the pointer is valid
+        let rtn = runtime::objc_retain(ptr.as_ptr() as *mut Object);
+        debug_assert_eq!(rtn, ptr.as_ptr() as *mut Object);
+        Retained {
+            ptr,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Autoreleases the retained pointer, meaning that the object is not
+    /// immediately released, but will be when the innermost / current
+    /// autorelease pool is drained.
+    ///
+    /// A pointer to the object is returned, but it's validity is only until
+    /// guaranteed until the innermost pool is drained.
+    #[doc(alias = "objc_autorelease")]
+    #[must_use = "If you don't intend to use the object any more, just drop it as usual"]
+    #[inline]
+    pub fn autorelease(self) -> NonNull<T> {
+        let ptr = mem::ManuallyDrop::new(self).ptr;
+        // SAFETY: The `ptr` is guaranteed to be valid and have at least one
+        // retain count.
+        // And because of the ManuallyDrop, we don't call the Drop
+        // implementation, so the object won't also be released there.
+        unsafe { runtime::objc_autorelease(ptr.as_ptr() as *mut Object) };
+        ptr
+    }
+
+    #[cfg(test)]
+    #[doc(alias = "retainCount")]
+    pub fn retain_count(&self) -> usize {
+        unsafe { msg_send![self.ptr.as_ptr() as *mut Object, retainCount] }
+    }
+}
+
+// TODO: #[may_dangle]
+// https://doc.rust-lang.org/nightly/nomicon/dropck.html
+impl<T> Drop for Retained<T> {
+    /// Releases the retained object
+    #[doc(alias = "objc_release")]
+    #[doc(alias = "release")]
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: The `ptr` is guaranteed to be valid and have at least one
+        // retain count
+        unsafe { runtime::objc_release(self.ptr.as_ptr() as *mut Object) };
+    }
+}
+
+impl<T> Clone for Retained<T> {
+    /// Makes a clone of the `Retained` object.
+    ///
+    /// This increases the object's reference count.
+    #[doc(alias = "objc_retain")]
+    #[doc(alias = "retain")]
+    #[inline]
+    fn clone(&self) -> Self {
+        // SAFETY: The `ptr` is guaranteed to be valid
+        unsafe { Self::retain(self.ptr) }
+    }
+}
+
+impl<T> Deref for Retained<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: TODO
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T: PartialEq> PartialEq for Retained<T> {
+    #[inline]
+    fn eq(&self, other: &Retained<T>) -> bool {
+        &**self == &**other
+    }
+
+    #[inline]
+    fn ne(&self, other: &Retained<T>) -> bool {
+        &**self != &**other
+    }
+}
+
+// TODO: impl PartialOrd, Ord and Eq
+
+impl<T: fmt::Display> fmt::Display for Retained<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Retained<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T> fmt::Pointer for Retained<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Pointer::fmt(&self.as_ptr(), f)
+    }
+}
+
+impl<T: hash::Hash> hash::Hash for Retained<T> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        (&**self).hash(state)
+    }
+}
+
+impl<T> borrow::Borrow<T> for Retained<T> {
+    fn borrow(&self) -> &T {
+        &**self
+    }
+}
+
+impl<T> AsRef<T> for Retained<T> {
+    fn as_ref(&self) -> &T {
+        &**self
+    }
+}
+
+impl<T> Unpin for Retained<T> {}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use super::Retained;
+    use crate::runtime::Object;
+
+    pub struct TestType {
+        _data: [u8; 0], // TODO: `UnsafeCell`?
+    }
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(size_of::<Retained<TestType>>(), size_of::<&TestType>());
+        assert_eq!(
+            size_of::<Option<Retained<TestType>>>(),
+            size_of::<&TestType>()
+        );
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[test]
+    fn test_clone() {
+        let obj: Retained<Object> = unsafe { Retained::new(msg_send![class!(NSObject), new]) };
+        assert!(obj.retain_count() == 1);
+
+        let cloned = obj.clone();
+        assert!(cloned.retain_count() == 2);
+        assert!(obj.retain_count() == 2);
+
+        drop(obj);
+        assert!(cloned.retain_count() == 1);
+    }
+}

--- a/src/rc/retained.rs
+++ b/src/rc/retained.rs
@@ -211,7 +211,8 @@ impl<T> Unpin for Retained<T> {}
 
 #[cfg(test)]
 mod tests {
-    use std::mem::size_of;
+    use core::mem::size_of;
+    use core::ptr::NonNull;
 
     use super::Retained;
     use crate::runtime::Object;
@@ -232,7 +233,9 @@ mod tests {
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     #[test]
     fn test_clone() {
-        let obj: Retained<Object> = unsafe { Retained::new(msg_send![class!(NSObject), new]) };
+        // TODO: Maybe make a way to return `Retained` directly?
+        let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
+        let obj: Retained<Object> = unsafe { Retained::new(NonNull::new(obj).unwrap()) };
         assert!(obj.retain_count() == 1);
 
         let cloned = obj.clone();

--- a/src/rc/retained.rs
+++ b/src/rc/retained.rs
@@ -51,6 +51,13 @@ pub struct Retained<T> {
     phantom: PhantomData<T>,
 }
 
+// SAFETY: TODO
+unsafe impl<T: Sync + Send> Send for Retained<T> {}
+
+// SAFETY: TODO
+unsafe impl<T: Sync + Send> Sync for Retained<T> {}
+
+
 impl<T> Retained<T> {
     /// Constructs a `Retained<T>` to an object that already has a +1 retain
     /// count. This will not retain the object.

--- a/src/rc/retained.rs
+++ b/src/rc/retained.rs
@@ -71,15 +71,15 @@ impl<T> Retained<T> {
     ///
     /// TODO: Something about there not being any mutable references.
     #[inline]
-    pub const unsafe fn new(ptr: NonNull<T>) -> Self {
-        Retained {
+    pub unsafe fn new(ptr: NonNull<T>) -> Self {
+        Self {
             ptr,
             phantom: PhantomData,
         }
     }
 
     #[inline]
-    pub const fn as_ptr(&self) -> *mut T {
+    pub fn as_ptr(&self) -> *mut T {
         self.ptr.as_ptr()
     }
 
@@ -96,7 +96,7 @@ impl<T> Retained<T> {
         // SAFETY: The caller upholds that the pointer is valid
         let rtn = runtime::objc_retain(ptr.as_ptr() as *mut Object);
         debug_assert_eq!(rtn, ptr.as_ptr() as *mut Object);
-        Retained {
+        Self {
             ptr,
             phantom: PhantomData,
         }
@@ -167,12 +167,12 @@ impl<T> Deref for Retained<T> {
 
 impl<T: PartialEq> PartialEq for Retained<T> {
     #[inline]
-    fn eq(&self, other: &Retained<T>) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         &**self == &**other
     }
 
     #[inline]
-    fn ne(&self, other: &Retained<T>) -> bool {
+    fn ne(&self, other: &Self) -> bool {
         &**self != &**other
     }
 }
@@ -193,7 +193,7 @@ impl<T: fmt::Debug> fmt::Debug for Retained<T> {
 
 impl<T> fmt::Pointer for Retained<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Pointer::fmt(&self.as_ptr(), f)
+        fmt::Pointer::fmt(&self.ptr.as_ptr(), f)
     }
 }
 

--- a/src/rc/retained.rs
+++ b/src/rc/retained.rs
@@ -9,8 +9,11 @@ use core::ptr::NonNull;
 use super::Owned;
 use crate::runtime::{self, Object};
 
-/// A smart pointer that strongly references an object, ensuring it won't be
+/// An smart pointer that strongly references an object, ensuring it won't be
 /// deallocated.
+///
+/// This doesn't own the object, so it is not safe to obtain a mutable
+/// reference from this. For that, see [`Owned`].
 ///
 /// This is guaranteed to have the same size as the underlying pointer.
 ///

--- a/src/rc/retained.rs
+++ b/src/rc/retained.rs
@@ -7,6 +7,7 @@ use core::ops::Deref;
 use core::ptr::NonNull;
 
 use crate::runtime::{self, Object};
+use super::Owned;
 
 /// A smart pointer that strongly references an object, ensuring it won't be
 /// deallocated.
@@ -208,6 +209,13 @@ impl<T> AsRef<T> for Retained<T> {
 }
 
 impl<T> Unpin for Retained<T> {}
+
+impl<T> From<Owned<T>> for Retained<T> {
+    fn from(obj: Owned<T>) -> Self {
+        // SAFETY: TODO
+        unsafe { Self::new(obj.ptr) }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/rc/retained.rs
+++ b/src/rc/retained.rs
@@ -129,6 +129,12 @@ impl<T> Retained<T> {
         }
     }
 
+    /// TODO
+    #[doc(alias = "objc_retainAutoreleasedReturnValue")]
+    pub unsafe fn retain_autoreleased_return(obj: &T) -> Self {
+        todo!()
+    }
+
     /// Autoreleases the retained pointer, meaning that the object is not
     /// immediately released, but will be when the innermost / current
     /// autorelease pool is drained.
@@ -150,12 +156,45 @@ impl<T> Retained<T> {
         ptr
     }
 
-    #[cfg(test)]
+    /// TODO
+    #[doc(alias = "objc_autoreleaseReturnValue")]
+    pub fn autorelease_return(self) -> *const T {
+        todo!()
+    }
+
+    /// TODO
+    ///
+    /// Equivalent to `Retained::retain(&obj).autorelease()`, but slightly
+    /// more efficient.
+    #[doc(alias = "objc_retainAutorelease")]
+    pub unsafe fn retain_and_autorelease(obj: &T) -> *const T {
+        todo!()
+    }
+
+    /// TODO
+    ///
+    /// Equivalent to `Retained::retain(&obj).autorelease_return()`, but
+    /// slightly more efficient.
+    #[doc(alias = "objc_retainAutoreleaseReturnValue")]
+    pub unsafe fn retain_and_autorelease_return(obj: &T) -> *const T {
+        todo!()
+    }
+
+    #[cfg(test)] // TODO
     #[doc(alias = "retainCount")]
     pub fn retain_count(&self) -> usize {
         unsafe { msg_send![self.ptr.as_ptr() as *mut Object, retainCount] }
     }
 }
+
+// TODO: Consider something like this
+// #[cfg(block)]
+// impl<T: Block> Retained<T> {
+//     #[doc(alias = "objc_retainBlock")]
+//     pub unsafe fn retain_block(block: &T) -> Self {
+//         todo!()
+//     }
+// }
 
 // TODO: #[may_dangle]
 // https://doc.rust-lang.org/nightly/nomicon/dropck.html


### PR DESCRIPTION
The smart pointer version of `StrongPtr`, but with more guarantees.

Notably, this has an `Deref<Target = T>` implementation, which makes it more ergonomic and safer to use.

See https://github.com/SSheldon/rust-objc/issues/95 for some of the reasoning behind this.

I'm thinking about removing `StrongPtr` completely in favor of this (since it's behaviour can be achieved with `Retained<Object>`), but please voice your opinion on this.