### PR TITLE
Make autoreleasepool take the pool as a parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Changed
+
+* The closure in `autoreleasepool` now takes an argument, a reference to the
+  pool.
+
 ## 0.2.7
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ exclude = [
 [features]
 exception = ["objc_exception"]
 verify_message = []
+unstable_autoreleasesafe = []
 
 [dependencies]
 malloc_buf = "1.0"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ let obj = unsafe {
 
 // Cloning retains the object an additional time
 let cloned = obj.clone();
-autoreleasepool(|| {
+autoreleasepool(|_| {
     // Autorelease consumes the StrongPtr, but won't
     // actually release until the end of an autoreleasepool
     cloned.autorelease();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ The bindings can be used on Linux or *BSD utilizing the
 #![crate_name = "objc"]
 #![crate_type = "lib"]
 
+#![cfg_attr(feature = "unstable_autoreleasesafe", feature(negative_impls, auto_traits))]
+
 #![warn(missing_docs)]
 
 extern crate malloc_buf;

--- a/src/rc/autorelease.rs
+++ b/src/rc/autorelease.rs
@@ -81,12 +81,26 @@ impl Drop for AutoreleasePool {
     }
 }
 
-/// A trait for the sole purpose of ensuring we can't pass an `&AutoreleasePool`
-/// through to the closure inside `autoreleasepool`
 #[cfg(feature = "unstable_autoreleasesafe")]
+/// Marks types that are safe to pass across the closure in an
+/// [`autoreleasepool`].
+///
+/// This is implemented for all types except [`AutoreleasePool`].
+///
+/// You should not need to implement this trait yourself.
+///
+/// # Safety
+///
+/// Must not be implemented for types that interract with the autorelease pool
+/// - so if you reimplement the `AutoreleasePool` struct, this should be
+/// negatively implemented for that.
+// TODO: We can technically make this private, but should we?
 pub unsafe auto trait AutoreleaseSafe {}
 #[cfg(feature = "unstable_autoreleasesafe")]
 impl !AutoreleaseSafe for AutoreleasePool {}
+
+// We use a macro here so that the function documentation is included whether
+// the feature is enabled or not.
 
 #[cfg(feature = "unstable_autoreleasesafe")]
 macro_rules! fn_autoreleasepool {
@@ -201,6 +215,7 @@ fn_autoreleasepool!(
     ///     // inner pool already.
     /// });
     /// ```
+    #[doc(alias = "@autoreleasepool")]
     pub fn autoreleasepool(f) {
         let pool = unsafe { AutoreleasePool::new() };
         f(&pool)

--- a/src/rc/autorelease.rs
+++ b/src/rc/autorelease.rs
@@ -81,73 +81,143 @@ impl Drop for AutoreleasePool {
     }
 }
 
-// TODO:
-// #![feature(negative_impls)]
-// #![feature(auto_traits)]
-// /// A trait for the sole purpose of ensuring we can't pass an `&AutoreleasePool`
-// /// through to the closure inside `autoreleasepool`
-// pub unsafe auto trait AutoreleaseSafe {}
-// // TODO: Unsure how negative impls work exactly
-// unsafe impl !AutoreleaseSafe for AutoreleasePool {}
-// unsafe impl !AutoreleaseSafe for &AutoreleasePool {}
-// unsafe impl !AutoreleaseSafe for &mut AutoreleasePool {}
+/// A trait for the sole purpose of ensuring we can't pass an `&AutoreleasePool`
+/// through to the closure inside `autoreleasepool`
+#[cfg(feature = "unstable_autoreleasesafe")]
+pub unsafe auto trait AutoreleaseSafe {}
+#[cfg(feature = "unstable_autoreleasesafe")]
+impl !AutoreleaseSafe for AutoreleasePool {}
 
-/// Execute `f` in the context of a new autorelease pool. The pool is drained
-/// after the execution of `f` completes.
-///
-/// This corresponds to `@autoreleasepool` blocks in Objective-C and Swift.
-///
-/// The pool is passed as a reference to the enclosing function to give it a
-/// lifetime parameter that autoreleased objects can refer to.
-///
-/// # Examples
-///
-/// ```rust
-/// use objc::{class, msg_send};
-/// use objc::rc::{autoreleasepool, AutoreleasePool};
-/// use objc::runtime::Object;
-///
-/// fn needs_lifetime_from_pool<'p>(_pool: &'p AutoreleasePool) -> &'p mut Object {
-///     let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
-///     let obj: *mut Object = unsafe { msg_send![obj, autorelease] };
-///     // SAFETY: Lifetime bounded by the pool
-///     unsafe { &mut *obj }
-/// }
-///
-/// autoreleasepool(|pool| {
-///     let obj = needs_lifetime_from_pool(pool);
-///     // Use `obj`
-/// });
-///
-/// // `obj` is deallocated when the pool ends
-/// ```
-///
-/// ```rust,compile_fail
-/// # use objc::{class, msg_send};
-/// # use objc::rc::{autoreleasepool, AutoreleasePool};
-/// # use objc::runtime::Object;
-/// #
-/// # fn needs_lifetime_from_pool<'p>(_pool: &'p AutoreleasePool) -> &'p mut Object {
-/// #     let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
-/// #     let obj: *mut Object = unsafe { msg_send![obj, autorelease] };
-/// #     unsafe { &mut *obj }
-/// # }
-/// #
-/// // Fails to compile because `obj` does not live long enough for us to
-/// // safely take it out of the pool.
-///
-/// let obj = autoreleasepool(|pool| {
-///     let obj = needs_lifetime_from_pool(pool);
-///     // Use `obj`
-///     obj
-/// });
-/// ```
-///
-/// TODO: More examples.
-pub fn autoreleasepool<T, F>(f: F) -> T
-where
-    for<'p> F: FnOnce(&'p AutoreleasePool) -> T, // + AutoreleaseSafe,
-{
-    let pool = unsafe { AutoreleasePool::new() };
-    f(&pool)
+#[cfg(feature = "unstable_autoreleasesafe")]
+macro_rules! fn_autoreleasepool {
+    {$(#[$fn_meta:meta])* $v:vis fn $fn:ident($f:ident) $b:block} => {
+        $(#[$fn_meta])*
+        $v fn $fn<T, F>($f: F) -> T
+        where
+            for<'p> F: FnOnce(&'p AutoreleasePool) -> T + AutoreleaseSafe,
+        {
+            $b
+        }
+    }
+}
+
+#[cfg(not(feature = "unstable_autoreleasesafe"))]
+macro_rules! fn_autoreleasepool {
+    {$(#[$fn_meta:meta])* $v:vis fn $fn:ident($f:ident) $b:block} => {
+        $(#[$fn_meta])*
+        $v fn $fn<T, F>($f: F) -> T
+        where
+            for<'p> F: FnOnce(&'p AutoreleasePool) -> T,
+        {
+            $b
+        }
+    }
+}
+
+fn_autoreleasepool!(
+    /// Execute `f` in the context of a new autorelease pool. The pool is
+    /// drained after the execution of `f` completes.
+    ///
+    /// This corresponds to `@autoreleasepool` blocks in Objective-C and
+    /// Swift.
+    ///
+    /// The pool is passed as a reference to the enclosing function to give it
+    /// a lifetime parameter that autoreleased objects can refer to.
+    ///
+    /// The given reference must not be used in an inner `autoreleasepool`,
+    /// doing so will be a compile error in a future release. You can test
+    /// this guarantee with the `unstable_autoreleasesafe` crate feature on
+    /// nightly Rust.
+    ///
+    /// So using `autoreleasepool` is unsound right now because of this
+    /// specific problem.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```rust
+    /// use objc::{class, msg_send};
+    /// use objc::rc::{autoreleasepool, AutoreleasePool};
+    /// use objc::runtime::Object;
+    ///
+    /// fn needs_lifetime_from_pool<'p>(_pool: &'p AutoreleasePool) -> &'p mut Object {
+    ///     let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
+    ///     let obj: *mut Object = unsafe { msg_send![obj, autorelease] };
+    ///     // SAFETY: Lifetime bounded by the pool
+    ///     unsafe { &mut *obj }
+    /// }
+    ///
+    /// autoreleasepool(|pool| {
+    ///     // Create `obj` and autorelease it to the pool
+    ///     let obj = needs_lifetime_from_pool(pool);
+    ///     // ... use `obj` here
+    ///     // `obj` is deallocated when the pool ends
+    /// });
+    /// ```
+    ///
+    /// Fails to compile because `obj` does not live long enough for us to
+    /// safely take it out of the pool:
+    ///
+    /// ```rust,compile_fail
+    /// # use objc::{class, msg_send};
+    /// # use objc::rc::{autoreleasepool, AutoreleasePool};
+    /// # use objc::runtime::Object;
+    /// #
+    /// # fn needs_lifetime_from_pool<'p>(_pool: &'p AutoreleasePool) -> &'p mut Object {
+    /// #     let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
+    /// #     let obj: *mut Object = unsafe { msg_send![obj, autorelease] };
+    /// #     unsafe { &mut *obj }
+    /// # }
+    /// #
+    /// let obj = autoreleasepool(|pool| {
+    ///     let obj = needs_lifetime_from_pool(pool);
+    ///     // Use `obj`
+    ///     obj
+    /// });
+    /// ```
+    ///
+    /// Incorrect usage which causes undefined behaviour:
+    ///
+    #[cfg_attr(feature = "unstable_autoreleasesafe", doc = "```rust,compile_fail")]
+    #[cfg_attr(not(feature = "unstable_autoreleasesafe"), doc = "```rust")]
+    /// # use objc::{class, msg_send};
+    /// # use objc::rc::{autoreleasepool, AutoreleasePool};
+    /// # use objc::runtime::Object;
+    /// #
+    /// # fn needs_lifetime_from_pool<'p>(_pool: &'p AutoreleasePool) -> &'p mut Object {
+    /// #     let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
+    /// #     let obj: *mut Object = unsafe { msg_send![obj, autorelease] };
+    /// #     unsafe { &mut *obj }
+    /// # }
+    /// #
+    /// autoreleasepool(|outer_pool| {
+    ///     let obj = autoreleasepool(|inner_pool| {
+    ///         let obj = needs_lifetime_from_pool(outer_pool);
+    ///         obj
+    ///     });
+    ///     // `obj` can wrongly be used here because it's lifetime was
+    ///     // assigned to the outer pool, even though it was released by the
+    ///     // inner pool already.
+    /// });
+    /// ```
+    pub fn autoreleasepool(f) {
+        let pool = unsafe { AutoreleasePool::new() };
+        f(&pool)
+    }
+);
+
+#[cfg(all(test, feature = "unstable_autoreleasesafe"))]
+mod tests {
+    use super::AutoreleaseSafe;
+    use crate::runtime::Object;
+
+    fn requires_autoreleasesafe<T: AutoreleaseSafe>() {}
+
+    #[test]
+    fn test_autoreleasesafe() {
+        requires_autoreleasesafe::<usize>();
+        requires_autoreleasesafe::<*mut Object>();
+        requires_autoreleasesafe::<&mut Object>();
+    }
 }

--- a/src/rc/autorelease.rs
+++ b/src/rc/autorelease.rs
@@ -21,8 +21,21 @@ pub struct AutoreleasePool {
     context: *mut c_void,
 }
 
+/// ```rust,compile_fail
+/// use objc::rc::AutoreleasePool;
+/// fn needs_sync<T: Send>() {}
+/// needs_sync::<AutoreleasePool>();
+/// ```
+/// ```rust,compile_fail
+/// use objc::rc::AutoreleasePool;
+/// fn needs_send<T: Send>() {}
+/// needs_send::<AutoreleasePool>();
+/// ```
+#[cfg(doctest)]
+pub struct AutoreleasePoolNotSendNorSync;
+
 impl AutoreleasePool {
-    /// Construct a new autoreleasepool.
+    /// Construct a new autorelease pool.
     ///
     /// Use the [`autoreleasepool`] block for a safe alternative.
     ///
@@ -36,7 +49,7 @@ impl AutoreleasePool {
     #[doc(alias = "objc_autoreleasePoolPush")]
     unsafe fn new() -> Self {
         // TODO: Make this function pub when we're more certain of the API
-        AutoreleasePool {
+        Self {
             context: objc_autoreleasePoolPush(),
         }
     }

--- a/src/rc/autorelease.rs
+++ b/src/rc/autorelease.rs
@@ -1,30 +1,140 @@
+use crate::runtime::{objc_autoreleasePoolPop, objc_autoreleasePoolPush};
 use std::os::raw::c_void;
-use crate::runtime::{objc_autoreleasePoolPush, objc_autoreleasePoolPop};
 
-// we use a struct to ensure that objc_autoreleasePoolPop during unwinding.
-struct AutoReleaseHelper {
+/// An Objective-C autorelease pool.
+///
+/// The pool is drained when dropped.
+///
+/// This is not `Send`, since `objc_autoreleasePoolPop` must be called on the
+/// same thread.
+///
+/// And this is not `Sync`, since you can only autorelease a reference to a
+/// pool on the current thread.
+///
+/// See [the clang documentation][clang-arc] and
+/// [this apple article][memory-mgmt] for more information on automatic
+/// reference counting.
+///
+/// [clang-arc]: https://clang.llvm.org/docs/AutomaticReferenceCounting.html
+/// [memory-mgmt]: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/MemoryMgmt.html
+pub struct AutoreleasePool {
     context: *mut c_void,
 }
 
-impl AutoReleaseHelper {
+impl AutoreleasePool {
+    /// Construct a new autoreleasepool.
+    ///
+    /// Use the [`autoreleasepool`] block for a safe alternative.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that when handing out `&'p AutoreleasePool` to
+    /// functions that this is the innermost pool.
+    ///
+    /// Additionally, the pools must be dropped in the same order they were
+    /// created.
+    #[doc(alias = "objc_autoreleasePoolPush")]
     unsafe fn new() -> Self {
-        AutoReleaseHelper { context: objc_autoreleasePoolPush() }
+        // TODO: Make this function pub when we're more certain of the API
+        AutoreleasePool {
+            context: objc_autoreleasePoolPush(),
+        }
     }
+
+    // TODO: Add helper functions to ensure (with debug_assertions) that the
+    // pool is innermost when its lifetime is tied to a reference.
 }
 
-impl Drop for AutoReleaseHelper {
+impl Drop for AutoreleasePool {
+    /// Drains the autoreleasepool.
+    ///
+    /// The [clang documentation] says that `@autoreleasepool` blocks are not
+    /// drained when exceptions occur because:
+    ///
+    /// > Not draining the pool during an unwind is apparently required by the
+    /// > Objective-C exceptions implementation.
+    ///
+    /// This was true in the past, but since [revision `371`] of
+    /// `objc-exception.m` (ships with MacOS 10.5) the exception is now
+    /// retained when `@throw` is encountered.
+    ///
+    /// Hence it is safe to drain the pool when unwinding.
+    ///
+    /// [clang documentation]: https://clang.llvm.org/docs/AutomaticReferenceCounting.html#autoreleasepool
+    /// [revision `371`]: https://opensource.apple.com/source/objc4/objc4-371/runtime/objc-exception.m.auto.html
+    #[doc(alias = "objc_autoreleasePoolPop")]
     fn drop(&mut self) {
         unsafe { objc_autoreleasePoolPop(self.context) }
     }
 }
 
-/**
-Execute `f` in the context of a new autorelease pool. The pool is drained
-after the execution of `f` completes.
+// TODO:
+// #![feature(negative_impls)]
+// #![feature(auto_traits)]
+// /// A trait for the sole purpose of ensuring we can't pass an `&AutoreleasePool`
+// /// through to the closure inside `autoreleasepool`
+// pub unsafe auto trait AutoreleaseSafe {}
+// // TODO: Unsure how negative impls work exactly
+// unsafe impl !AutoreleaseSafe for AutoreleasePool {}
+// unsafe impl !AutoreleaseSafe for &AutoreleasePool {}
+// unsafe impl !AutoreleaseSafe for &mut AutoreleasePool {}
 
-This corresponds to `@autoreleasepool` blocks in Objective-C and Swift.
-*/
-pub fn autoreleasepool<T, F: FnOnce() -> T>(f: F) -> T {
-    let _context = unsafe { AutoReleaseHelper::new() };
-    f()
+/// Execute `f` in the context of a new autorelease pool. The pool is drained
+/// after the execution of `f` completes.
+///
+/// This corresponds to `@autoreleasepool` blocks in Objective-C and Swift.
+///
+/// The pool is passed as a reference to the enclosing function to give it a
+/// lifetime parameter that autoreleased objects can refer to.
+///
+/// # Examples
+///
+/// ```rust
+/// use objc::{class, msg_send};
+/// use objc::rc::{autoreleasepool, AutoreleasePool};
+/// use objc::runtime::Object;
+///
+/// fn needs_lifetime_from_pool<'p>(_pool: &'p AutoreleasePool) -> &'p mut Object {
+///     let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
+///     let obj: *mut Object = unsafe { msg_send![obj, autorelease] };
+///     // SAFETY: Lifetime bounded by the pool
+///     unsafe { &mut *obj }
+/// }
+///
+/// autoreleasepool(|pool| {
+///     let obj = needs_lifetime_from_pool(pool);
+///     // Use `obj`
+/// });
+///
+/// // `obj` is deallocated when the pool ends
+/// ```
+///
+/// ```rust,compile_fail
+/// # use objc::{class, msg_send};
+/// # use objc::rc::{autoreleasepool, AutoreleasePool};
+/// # use objc::runtime::Object;
+/// #
+/// # fn needs_lifetime_from_pool<'p>(_pool: &'p AutoreleasePool) -> &'p mut Object {
+/// #     let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
+/// #     let obj: *mut Object = unsafe { msg_send![obj, autorelease] };
+/// #     unsafe { &mut *obj }
+/// # }
+/// #
+/// // Fails to compile because `obj` does not live long enough for us to
+/// // safely take it out of the pool.
+///
+/// let obj = autoreleasepool(|pool| {
+///     let obj = needs_lifetime_from_pool(pool);
+///     // Use `obj`
+///     obj
+/// });
+/// ```
+///
+/// TODO: More examples.
+pub fn autoreleasepool<T, F>(f: F) -> T
+where
+    for<'p> F: FnOnce(&'p AutoreleasePool) -> T, // + AutoreleaseSafe,
+{
+    let pool = unsafe { AutoreleasePool::new() };
+    f(&pool)
 }

--- a/src/rc/mod.rs
+++ b/src/rc/mod.rs
@@ -44,6 +44,8 @@ mod strong;
 mod weak;
 mod autorelease;
 
+#[cfg(feature = "unstable_autoreleasesafe")]
+pub use self::autorelease::AutoreleaseSafe;
 pub use self::autorelease::{autoreleasepool, AutoreleasePool};
 pub use self::strong::StrongPtr;
 pub use self::weak::WeakPtr;

--- a/src/rc/mod.rs
+++ b/src/rc/mod.rs
@@ -26,7 +26,7 @@ let obj = unsafe {
 
 // Cloning retains the object an additional time
 let cloned = obj.clone();
-autoreleasepool(|| {
+autoreleasepool(|_| {
     // Autorelease consumes the StrongPtr, but won't
     // actually release until the end of an autoreleasepool
     cloned.autorelease();
@@ -44,9 +44,9 @@ mod strong;
 mod weak;
 mod autorelease;
 
+pub use self::autorelease::{autoreleasepool, AutoreleasePool};
 pub use self::strong::StrongPtr;
 pub use self::weak::WeakPtr;
-pub use self::autorelease::autoreleasepool;
 
 // These tests use NSObject, which isn't present for GNUstep
 #[cfg(all(test, any(target_os = "macos", target_os = "ios")))]
@@ -112,9 +112,9 @@ mod tests {
         }
         let cloned = obj.clone();
 
-        autoreleasepool(|| {
-                        obj.autorelease();
-                        assert!(retain_count(*cloned) == 2);
+        autoreleasepool(|_| {
+            obj.autorelease();
+            assert!(retain_count(*cloned) == 2);
         });
 
         // make sure that the autoreleased value has been released


### PR DESCRIPTION
The pool is given as a reference, and the lifetime of the reference is the same as the lifetime of autoreleased objects in the pool. This allows us to bound the lifetimes of autoreleased objects, thereby making them safe to return.

Extracted from https://github.com/SSheldon/rust-objc/pull/98, see https://github.com/SSheldon/rust-objc/issues/95 for some more examples and the reasoning behind this.

## ~Unsoundness~ Fixed.

This is unsound until we can prevent people from doing something like:
```rust
autoreleasepool(|outer_pool| {
    let obj = autoreleasepool(|inner_pool| {
        let obj = needs_lifetime_from_pool(outer_pool);
        obj
    });
    // obj can wrongly be used here because it's lifetime was assigned to the outer pool, but it has been released by the inner pool already
});
```

~I think this is possible to statically prevent using the nightly `auto_traits` + `negative_impls` features.~ Done!

~It might also be possible to make a stable implementation for `debug_assertions` builds that panic if it happens.~ Done!