### PR TITLE
Add `unstable_extern_types` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,11 @@ exclude = [
 [features]
 exception = ["objc_exception"]
 verify_message = []
+unstable_extern_types = []
 
 [dependencies]
 malloc_buf = "1.0"
-objc-encode = "1.0"
+objc-encode = { git = "https://github.com/madsmtm/rust-objc-encode", branch = "unsized" }
 
 [dependencies.objc_exception]
 version = "0.1"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -38,7 +38,7 @@ impl CachedSel {
 /// Allows storing a `Class` reference in a static and lazily loading it.
 #[doc(hidden)]
 pub struct CachedClass {
-    ptr: AtomicPtr<Class>
+    ptr: AtomicPtr<c_void>
 }
 
 impl CachedClass {
@@ -60,7 +60,7 @@ impl CachedClass {
             self.ptr.store(cls as *mut _, Ordering::Relaxed);
             cls.as_ref()
         } else {
-            Some(&*ptr)
+            Some(&*(ptr as *const Class))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ The bindings can be used on Linux or *BSD utilizing the
 #![crate_name = "objc"]
 #![crate_type = "lib"]
 
+#![cfg_attr(feature = "unstable_extern_types", feature(extern_types))]
+
 #![warn(missing_docs)]
 
 extern crate malloc_buf;

--- a/src/message/apple/mod.rs
+++ b/src/message/apple/mod.rs
@@ -20,7 +20,7 @@ use self::arch::{msg_send_fn, msg_send_super_fn};
 
 pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: Sel, args: A)
         -> Result<R, MessageError>
-        where T: Message, A: MessageArguments, R: Any {
+        where T: ?Sized + Message, A: MessageArguments, R: Any {
     let receiver = obj as *mut T as *mut Object;
     let msg_send_fn = msg_send_fn::<R>();
     objc_try!({
@@ -30,7 +30,7 @@ pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: Sel, args: A)
 
 pub unsafe fn send_super_unverified<T, A, R>(obj: *const T, superclass: &Class,
         sel: Sel, args: A) -> Result<R, MessageError>
-        where T: Message, A: MessageArguments, R: Any {
+        where T: ?Sized + Message, A: MessageArguments, R: Any {
     let sup = Super { receiver: obj as *mut T as *mut Object, superclass: superclass };
     let receiver = &sup as *const Super as *mut Object;
     let msg_send_fn = msg_send_super_fn::<R>();

--- a/src/message/gnustep.rs
+++ b/src/message/gnustep.rs
@@ -11,7 +11,7 @@ extern {
 
 pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: Sel, args: A)
         -> Result<R, MessageError>
-        where T: Message, A: MessageArguments, R: Any {
+        where T: ?Sized + Message, A: MessageArguments, R: Any {
     if obj.is_null() {
         return mem::zeroed();
     }
@@ -25,7 +25,7 @@ pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: Sel, args: A)
 
 pub unsafe fn send_super_unverified<T, A, R>(obj: *const T, superclass: &Class,
         sel: Sel, args: A) -> Result<R, MessageError>
-        where T: Message, A: MessageArguments, R: Any {
+        where T: ?Sized + Message, A: MessageArguments, R: Any {
     let receiver = obj as *mut T as *mut Object;
     let sup = Super { receiver: receiver, superclass: superclass };
     let msg_send_fn = objc_msg_lookup_super(&sup, sel);

--- a/src/rc/weak.rs
+++ b/src/rc/weak.rs
@@ -1,5 +1,4 @@
 use std::cell::UnsafeCell;
-use std::ptr;
 
 use crate::runtime::{Object, self};
 use super::StrongPtr;
@@ -16,7 +15,7 @@ impl WeakPtr {
     /// Constructs a `WeakPtr` to the given object.
     /// Unsafe because the caller must ensure the given object pointer is valid.
     pub unsafe fn new(obj: *mut Object) -> Self {
-        let ptr = Box::new(UnsafeCell::new(ptr::null_mut()));
+        let ptr = Box::new(UnsafeCell::new(0 as *mut Object));
         runtime::objc_initWeak(ptr.get(), obj);
         WeakPtr(ptr)
     }
@@ -41,7 +40,7 @@ impl Drop for WeakPtr {
 
 impl Clone for WeakPtr {
     fn clone(&self) -> Self {
-        let ptr = Box::new(UnsafeCell::new(ptr::null_mut()));
+        let ptr = Box::new(UnsafeCell::new(0 as *mut Object));
         unsafe {
             runtime::objc_copyWeak(ptr.get(), self.0.get());
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -39,7 +39,13 @@ pub struct Sel {
 
 /// A marker type to be embedded into other types just so that they cannot be
 /// constructed externally.
+#[cfg(not(feature = "unstable_extern_types"))]
 type PrivateMarker = [u8; 0];
+
+#[cfg(feature = "unstable_extern_types")]
+extern {
+    type PrivateMarker;
+}
 
 /// A type that represents an instance variable.
 #[repr(C)]


### PR DESCRIPTION
To see what changes we'd have to make in the library to use `extern type` ([RFC-1861](https://rust-lang.github.io/rfcs/1861-extern-types.html)) when it's is stabilized.

This requires https://github.com/SSheldon/rust-objc-encode/pull/7.

Unfortunately had to change some usage of `ptr::null[_mut]` to `0 as *const/mut X`, and change the inner type of `AtomicPtr`, see https://github.com/rust-lang/rust/issues/42847.