### PR TITLE
Make `Sel` an opaque struct like `Ivar`, `Method,` `Class`, `Protocol` and `Object`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ let mut decl = ClassDecl::new("MyNumber", superclass).unwrap();
 decl.add_ivar::<u32>("_number");
 
 // Add an ObjC method for getting the number
-extern fn my_number_get(this: &Object, _cmd: Sel) -> u32 {
+extern fn my_number_get(this: &Object, _cmd: &Sel) -> u32 {
     unsafe { *this.get_ivar("_number") }
 }
 unsafe {
     decl.add_method(sel!(number),
-        my_number_get as extern fn(&Object, Sel) -> u32);
+        my_number_get as extern fn(&Object, &Sel) -> u32);
 }
 
 decl.register();

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,9 +1,11 @@
 use crate::runtime::{Class, Object, Sel};
 use crate::{Encode, Encoding};
 
-unsafe impl Encode for Sel {
+unsafe impl<'a> Encode for &'a Sel {
     const ENCODING: Encoding<'static> = Encoding::Sel;
 }
+
+// We don't implement `Encode` for `&mut Sel` because selectors are immutable.
 
 unsafe impl<'a> Encode for &'a Object {
     const ENCODING: Encoding<'static> = Encoding::Object;
@@ -62,6 +64,7 @@ mod tests {
         assert!(<&Object>::ENCODING.to_string() == "@");
         assert!(<*mut Object>::ENCODING.to_string() == "@");
         assert!(<&Class>::ENCODING.to_string() == "#");
-        assert!(Sel::ENCODING.to_string() == ":");
+        assert!(<*const Sel>::ENCODING.to_string() == ":");
+        assert!(<&Sel>::ENCODING.to_string() == ":");
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,7 +27,7 @@ macro_rules! class {
 }
 
 /**
-Registers a selector, returning a `Sel`.
+Registers a selector, returning a `&'static Sel`.
 
 # Example
 ```

--- a/src/message/apple/mod.rs
+++ b/src/message/apple/mod.rs
@@ -18,7 +18,7 @@ mod arch;
 
 use self::arch::{msg_send_fn, msg_send_super_fn};
 
-pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: Sel, args: A)
+pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: &Sel, args: A)
         -> Result<R, MessageError>
         where T: Message, A: MessageArguments, R: Any {
     let receiver = obj as *mut T as *mut Object;
@@ -29,7 +29,7 @@ pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: Sel, args: A)
 }
 
 pub unsafe fn send_super_unverified<T, A, R>(obj: *const T, superclass: &Class,
-        sel: Sel, args: A) -> Result<R, MessageError>
+        sel: &Sel, args: A) -> Result<R, MessageError>
         where T: Message, A: MessageArguments, R: Any {
     let sup = Super { receiver: obj as *mut T as *mut Object, superclass: superclass };
     let receiver = &sup as *const Super as *mut Object;

--- a/src/message/gnustep.rs
+++ b/src/message/gnustep.rs
@@ -5,11 +5,11 @@ use crate::runtime::{Class, Object, Imp, Sel};
 use super::{Message, MessageArguments, MessageError, Super};
 
 extern {
-    fn objc_msg_lookup(receiver: *mut Object, op: Sel) -> Imp;
-    fn objc_msg_lookup_super(sup: *const Super, sel: Sel) -> Imp;
+    fn objc_msg_lookup(receiver: *mut Object, op: &Sel) -> Imp;
+    fn objc_msg_lookup_super(sup: *const Super, sel: &Sel) -> Imp;
 }
 
-pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: Sel, args: A)
+pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: &Sel, args: A)
         -> Result<R, MessageError>
         where T: Message, A: MessageArguments, R: Any {
     if obj.is_null() {
@@ -24,7 +24,7 @@ pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: Sel, args: A)
 }
 
 pub unsafe fn send_super_unverified<T, A, R>(obj: *const T, superclass: &Class,
-        sel: Sel, args: A) -> Result<R, MessageError>
+        sel: &Sel, args: A) -> Result<R, MessageError>
         where T: Message, A: MessageArguments, R: Any {
     let receiver = obj as *mut T as *mut Object;
     let sup = Super { receiver: receiver, superclass: superclass };

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -59,7 +59,7 @@ pub fn custom_class() -> &'static Class {
 
     REGISTER_CUSTOM_CLASS.call_once(|| {
         // The runtime will call this method, so it has to be implemented
-        extern fn custom_obj_class_initialize(_this: &Class, _cmd: Sel) { }
+        extern fn custom_obj_class_initialize(_this: &Class, _cmd: &Sel) { }
 
         let mut decl = ClassDecl::root("CustomObject", custom_obj_class_initialize).unwrap();
         let proto = custom_protocol();
@@ -67,43 +67,43 @@ pub fn custom_class() -> &'static Class {
         decl.add_protocol(proto);
         decl.add_ivar::<u32>("_foo");
 
-        extern fn custom_obj_set_foo(this: &mut Object, _cmd: Sel, foo: u32) {
+        extern fn custom_obj_set_foo(this: &mut Object, _cmd: &Sel, foo: u32) {
             unsafe { this.set_ivar::<u32>("_foo", foo); }
         }
 
-        extern fn custom_obj_get_foo(this: &Object, _cmd: Sel) -> u32 {
+        extern fn custom_obj_get_foo(this: &Object, _cmd: &Sel) -> u32 {
             unsafe { *this.get_ivar::<u32>("_foo") }
         }
 
-        extern fn custom_obj_get_struct(_this: &Object, _cmd: Sel) -> CustomStruct {
+        extern fn custom_obj_get_struct(_this: &Object, _cmd: &Sel) -> CustomStruct {
             CustomStruct { a: 1, b: 2, c: 3, d: 4 }
         }
 
-        extern fn custom_obj_class_method(_this: &Class, _cmd: Sel) -> u32 {
+        extern fn custom_obj_class_method(_this: &Class, _cmd: &Sel) -> u32 {
             7
         }
 
-        extern fn custom_obj_set_bar(this: &mut Object, _cmd: Sel, bar: u32) {
+        extern fn custom_obj_set_bar(this: &mut Object, _cmd: &Sel, bar: u32) {
             unsafe { this.set_ivar::<u32>("_foo", bar) ;}
         }
 
-        extern fn custom_obj_add_number_to_number(_this: &Class, _cmd: Sel, fst: i32, snd: i32) -> i32 {
+        extern fn custom_obj_add_number_to_number(_this: &Class, _cmd: &Sel, fst: i32, snd: i32) -> i32 {
             fst + snd
         }
 
         unsafe {
-            let set_foo: extern fn(&mut Object, Sel, u32) = custom_obj_set_foo;
+            let set_foo: extern fn(&mut Object, &Sel, u32) = custom_obj_set_foo;
             decl.add_method(sel!(setFoo:), set_foo);
-            let get_foo: extern fn(&Object, Sel) -> u32 = custom_obj_get_foo;
+            let get_foo: extern fn(&Object, &Sel) -> u32 = custom_obj_get_foo;
             decl.add_method(sel!(foo), get_foo);
-            let get_struct: extern fn(&Object, Sel) -> CustomStruct = custom_obj_get_struct;
+            let get_struct: extern fn(&Object, &Sel) -> CustomStruct = custom_obj_get_struct;
             decl.add_method(sel!(customStruct), get_struct);
-            let class_method: extern fn(&Class, Sel) -> u32 = custom_obj_class_method;
+            let class_method: extern fn(&Class, &Sel) -> u32 = custom_obj_class_method;
             decl.add_class_method(sel!(classFoo), class_method);
 
-            let protocol_instance_method: extern fn(&mut Object, Sel, u32) = custom_obj_set_bar;
+            let protocol_instance_method: extern fn(&mut Object, &Sel, u32) = custom_obj_set_bar;
             decl.add_method(sel!(setBar:), protocol_instance_method);
-            let protocol_class_method: extern fn(&Class, Sel, i32, i32) -> i32 = custom_obj_add_number_to_number;
+            let protocol_class_method: extern fn(&Class, &Sel, i32, i32) -> i32 = custom_obj_add_number_to_number;
             decl.add_class_method(sel!(addNumber:toNumber:), protocol_class_method);
         }
 
@@ -156,7 +156,7 @@ pub fn custom_subclass() -> &'static Class {
         let superclass = custom_class();
         let mut decl = ClassDecl::new("CustomSubclassObject", superclass).unwrap();
 
-        extern fn custom_subclass_get_foo(this: &Object, _cmd: Sel) -> u32 {
+        extern fn custom_subclass_get_foo(this: &Object, _cmd: &Sel) -> u32 {
             let foo: u32 = unsafe {
                 msg_send![super(this, custom_class()), foo]
             };
@@ -164,7 +164,7 @@ pub fn custom_subclass() -> &'static Class {
         }
 
         unsafe {
-            let get_foo: extern fn(&Object, Sel) -> u32 = custom_subclass_get_foo;
+            let get_foo: extern fn(&Object, &Sel) -> u32 = custom_subclass_get_foo;
             decl.add_method(sel!(foo), get_foo);
         }
 


### PR DESCRIPTION
The discrepancy between usage of `Class`/`Object`/... and `Sel` annoyed me, the others were used behind pointers / references, while `Sel` was consumed directly.

This changes the definition of `Sel` to be like the other types (so it has to be used as `&Sel`), and also opens up for the possiblity of non-static selectors (if that ever becomes a thing).

This is a breaking change, but fortunately most cases where `Sel` is used in user code (e.g. `add_method`) the error is caught at compile-time, with recommendations on how to fix it.