### PR TITLE
Add apple tvos support

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -26,10 +26,10 @@ macro_rules! objc_try {
 
 mod verify;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
 #[path = "apple/mod.rs"]
 mod platform;
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 #[path = "gnustep.rs"]
 mod platform;
 

--- a/src/rc/mod.rs
+++ b/src/rc/mod.rs
@@ -49,7 +49,7 @@ pub use self::weak::WeakPtr;
 pub use self::autorelease::autoreleasepool;
 
 // These tests use NSObject, which isn't present for GNUstep
-#[cfg(all(test, any(target_os = "macos", target_os = "ios")))]
+#[cfg(all(test, any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 mod tests {
     use crate::runtime::Object;
     use super::StrongPtr;


### PR DESCRIPTION
This PR allows using rust-objc lib to target [tier 3 *-apple builds](https://doc.rust-lang.org/nightly/rustc/platform-support/apple-tvos.html):

- Apple tvOS on aarch64
- Apple tvOS Simulator on x86_64